### PR TITLE
Add POD_NAME env to ovnkube-node

### DIFF
--- a/bindata/ovnkube-node/daemonset.yaml
+++ b/bindata/ovnkube-node/daemonset.yaml
@@ -162,6 +162,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         ports:
         - name: metrics-port
           containerPort: 29103


### PR DESCRIPTION
Without POD_NAME set, ovnkube-node will error out when generating the proxier health server.